### PR TITLE
[RHDHPAI-519] Allow software templates to be viewed, but not executed

### DIFF
--- a/developer-hub/app-config.yaml
+++ b/developer-hub/app-config.yaml
@@ -61,6 +61,11 @@ data:
                 - resolver: emailMatchingUserEntityProfileEmail
       rules:
           - allow: [Component, Group, User, Resource, Location, Template, API]
+      locations:
+        - type: url
+          target: https://github.com/redhat-ai-dev/ai-lab-template/blob/main/all.yaml
+          rules:
+            - allow: [Location, Template]
     lightspeed:
       servers:
       - id: 'ollama-server'

--- a/developer-hub/rhdh-rbac-policy.yaml
+++ b/developer-hub/rhdh-rbac-policy.yaml
@@ -21,6 +21,7 @@ data:
     p, role:default/rhdhpai-users, catalog.entity.create, create, allow
     p, role:default/rhdhpai-users, scaffolder-template, read, allow
     p, role:default/rhdhpai-users, scaffolder.task.read, read, allow
+    p, role:default/rhdhpai-users, scaffolder.task.create, create, allow
 
     g, user:default/afred, role:default/rhdhpai-users
     g, user:default/bsutter, role:default/rhdhpai-users


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/RHDHPAI-519

- Updates the rhdh-rbac-policy file to add an additional role, as it's needed to allow users to step through the software template tasks
- Adds the [ai-lab-templates](https://github.com/redhat-ai-dev/ai-lab-template) to the Backstage app-config.yaml, allowing them to show up in the catalog