### PR TITLE
Create template-executers role to allow template execution

### DIFF
--- a/developer-hub/rhdh-rbac-policy.yaml
+++ b/developer-hub/rhdh-rbac-policy.yaml
@@ -60,3 +60,7 @@ data:
     g, user:default/erwangranger, role:default/rhdhpai-users
     g, user:default/catherineweeks, role:default/rhdhpai-users
     g, user:default/beaumorley, role:default/rhdhpai-users
+
+    p, role:default/template-executers, scaffolder.action.execute, use, allow
+    g, user:default/mfaisal, role:default/template-executers
+    g, user:default/jcollier, role:default/template-executers


### PR DESCRIPTION
Adds a new `template-executers` role which allows for software templates to be executed (as the current default `rhdhpai-users` role does not allow it), and adds two users to it:

   - Myself
   - @maysunfaisal 

@maysunfaisal Please review