### PR TITLE
Upgrade Lightspeed plugin to latest in RHDH

### DIFF
--- a/developer-hub/app-config.yaml
+++ b/developer-hub/app-config.yaml
@@ -68,9 +68,10 @@ data:
             - allow: [Location, Template]
     lightspeed:
       servers:
-      - id: 'ollama-server'
+      - id: team_cluster
         url: "${OLLAMA_URL}"
         token: "${OLLAMA_TOKEN}"
+        type: "openai"
     permission:
       enabled: true
       rbac:

--- a/developer-hub/backstage.yaml
+++ b/developer-hub/backstage.yaml
@@ -21,3 +21,44 @@ spec:
       enabled: true
   database:
     enableLocalDb: true
+  deployment:
+    patch:
+      spec:
+        template:
+          spec:
+            containers:
+              - env:
+                  - name: PROJECT
+                    value: rhdh
+                  - name: RCS_CONFIG_FILE
+                    value: /app-root/config/rcsconfig.yaml
+                  - name: RHDH_CONFIG_FILE
+                    value: /app-root/config/app-config-rhdh.yaml
+                envFrom:
+                  - secretRef:
+                      name: team-cluster-key
+                  - secretRef:
+                      name: secrets-rhdh
+                image: 'quay.io/redhat-ai-dev/road-core-service:latest'
+                name: road-core-sidecar
+                ports:
+                  - containerPort: 8080
+                    name: rcs-backend
+                    protocol: TCP
+                volumeMounts:
+                  - mountPath: /app-root/config/rcsconfig.yaml
+                    name: rcsconfig
+                    subPath: rcsconfig.yaml
+                  - mountPath: /app-root/config/team-cluster-key/team_cluster_key.txt
+                    name: openai
+                    subPath: team_cluster_key.txt
+                  - mountPath: /app-root/config/app-config-rhdh.yaml
+                    name: app-config-rhdh
+                    subPath: app-config-rhdh.yaml
+            volumes:
+              - configMap:
+                  name: rcsconfig
+                name: rcsconfig
+              - name: openai
+                secret:
+                  secretName: team-cluster-key

--- a/developer-hub/dynamic-plugins.yaml
+++ b/developer-hub/dynamic-plugins.yaml
@@ -15,7 +15,7 @@ data:
         disabled: false
       - package:  ./dynamic-plugins/dist/backstage-community-plugin-catalog-backend-module-keycloak-dynamic
         disabled: false
-      - package: oci://quay.io/karthik_jk/lightspeed:v0.3.3!red-hat-developer-hub-backstage-plugin-lightspeed
+      - package: oci://quay.io/karthik_jk/lightspeed:latest!red-hat-developer-hub-backstage-plugin-lightspeed
         disabled: false
         pluginConfig:
           dynamicPlugins:
@@ -32,5 +32,5 @@ data:
                     menuItem:
                       icon: LightspeedIcon
                       text: Lightspeed
-      - package: oci://quay.io/karthik_jk/lightspeed:v0.3.3!red-hat-developer-hub-backstage-plugin-lightspeed-backend-dynamic
+      - package: oci://quay.io/karthik_jk/lightspeed:latest!red-hat-developer-hub-backstage-plugin-lightspeed-backend
         disabled: false

--- a/developer-hub/kustomization.yaml
+++ b/developer-hub/kustomization.yaml
@@ -5,5 +5,6 @@ resources:
   - app-config.yaml
   - dynamic-plugins.yaml
   - rhdh-rbac-policy.yaml
+  - rcsconfig.yaml
 
 namespace: developer-hub

--- a/developer-hub/rcsconfig.yaml
+++ b/developer-hub/rcsconfig.yaml
@@ -1,0 +1,28 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: rcsconfig
+  namespace: developer-hub
+data:
+  rcsconfig.yaml: |
+    llm_providers:
+      - name: dummy
+        type: openai
+        url: https://dummy.com
+        models:
+          - name: dummymodel
+    ols_config:
+      conversation_cache:
+        type: memory
+        memory:
+          max_entries: 1000
+      authentication_config:
+        module: "noop"
+      default_provider: dummy
+      default_model: dummymodel
+      query_validation_method: disabled
+    dev_config:
+      enable_dev_ui: false
+      disable_auth: false
+      disable_tls: true
+      enable_system_prompt_override: true


### PR DESCRIPTION
Resolves https://issues.redhat.com/browse/RHDHPAI-838

Updates the GitOps configuration for RHDH on our dev cluster to include the latest version of the Lightspeed plugin. These changes have already been made on the remote cluster, and this PR is just needed to re-synchronize the GitOps repo with the cluster