### PR TITLE
Add llama-stack to ROSA gitops

### DIFF
--- a/llama-stack/README.md
+++ b/llama-stack/README.md
@@ -1,0 +1,10 @@
+# llama-stack
+
+This ArgoCD application configures an instance of llama stack, pointing to the instance of Ollama deployed via this repository
+
+## Prerequisites
+
+Before deploying this application, a secret, `llama-stack-secret` must exist in the same namespace, with the following key-value pairs:
+
+- `OLLAMA_URL`: The hostname of the Ollama instance
+- `OLLAMA_API_TOKEN`: An API key used to access the Ollama instance (if needed)

--- a/llama-stack/README.md
+++ b/llama-stack/README.md
@@ -8,3 +8,4 @@ Before deploying this application, a secret, `llama-stack-secret` must exist in 
 
 - `OLLAMA_URL`: The hostname of the Ollama instance
 - `OLLAMA_API_TOKEN`: An API key used to access the Ollama instance (if needed)
+- `INFERENCE_MODEL`: The model used by Llama stack instance

--- a/llama-stack/deployment.yaml
+++ b/llama-stack/deployment.yaml
@@ -1,0 +1,86 @@
+﻿kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: llamastack-deployment
+  annotations:
+    argocd.argoproj.io/sync-wave: "5"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: llamastack
+  template:
+    metadata:
+      labels:
+        app: llamastack
+    spec:
+      volumes:
+        - name: run-config-volume
+          configMap:
+            name: run-config
+            defaultMode: 420
+        - name: llama-persist
+          persistentVolumeClaim:
+            claimName: llama-persist
+        - name: cache
+          emptyDir: {}
+        - name: pythain
+          emptyDir: {}
+      containers:
+        - resources: {}
+          terminationMessagePath: /dev/termination-log
+          name: llamastack
+          env:
+            - name: MAX_TOKENS
+              value: '128000'
+            - name: VLLM_MAX_TOKENS
+              value: '128000'
+            - name: LLAMA3B_URL
+              value: 'https://llama32-3b.llama-serve.svc.cluster.local/v1'
+            - name: LLAMA3B_MODEL
+              value: llama32-3b
+            - name: GRANITE_URL
+              value: 'https://granite32-8b.llama-serve.svc.cluster.local/v1'
+            - name: GRANITE_MODEL
+              value: granite32-8b
+            - name: VLLM_API_TOKEN
+              value: fake
+            - name: CUSTOM_TIKTOKEN_CACHE_DIR
+              value: /app/cache
+            - name: MILVUS_DB_PATH
+              value: milvus.db
+            - name: LLAMA_STACK_LOGGING
+              value: all=debug
+          envFrom:
+          - secretRef:
+              name: llama-stack-secret
+          ports:
+            - containerPort: 8321
+              protocol: TCP
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: pythain
+              mountPath: /pythainlp-data
+            - name: run-config-volume
+              mountPath: /app-config
+            - name: llama-persist
+              mountPath: /.llama
+            - name: cache
+              mountPath: /.cache
+          terminationMessagePolicy: File
+          image: 'quay.io/redhat-et/llama:vllm-0.2.6'
+          args:
+            - '--config'
+            - /app-config/config.yaml
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      securityContext: {}
+      schedulerName: default-scheduler
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  revisionHistoryLimit: 10
+  progressDeadlineSeconds: 600

--- a/llama-stack/kustomization.yaml
+++ b/llama-stack/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - deployment.yaml
+  - pvc.yaml
+  - service.yaml
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+configMapGenerator:
+  - name: run-config
+    files:
+      - config.yaml=run.yaml

--- a/llama-stack/pvc.yaml
+++ b/llama-stack/pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: llama-persist
+  annotations:
+    openshift.io/description: "Storage for llama stack state"
+    argocd.argoproj.io/sync-wave: "5"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Gi

--- a/llama-stack/run.yaml
+++ b/llama-stack/run.yaml
@@ -1,0 +1,137 @@
+version: '2'
+image_name: remote-vllm
+apis:
+- agents
+- datasetio
+- eval
+- inference
+- safety
+- scoring
+- telemetry
+- tool_runtime
+- vector_io
+providers:
+  inference:
+  - provider_id: vllm-inference
+    provider_type: remote::vllm
+    config:
+      url: ${env.OLLAMA_URL:http://localhost:8000/v1}
+      max_tokens: ${env.VLLM_MAX_TOKENS:4096}
+      api_token: ${env.OLLAMA_API_TOKEN:fake}
+      tls_verify: false
+  - provider_id: sentence-transformers
+    provider_type: inline::sentence-transformers
+    config: {}
+  vector_io:
+  - provider_id: milvus
+    provider_type: inline::milvus
+    config:
+      db_path: ${env.MILVUS_DB_PATH}
+  safety:
+  - provider_id: llama-guard
+    provider_type: inline::llama-guard
+    config:
+      excluded_categories: []
+  agents:
+  - provider_id: meta-reference
+    provider_type: inline::meta-reference
+    config:
+      persistence_store:
+        type: sqlite
+        namespace: null
+        db_path: ${env.SQLITE_STORE_DIR:~/.llama/distributions/remote-vllm}/agents_store.db
+      responses_store:
+        type: sqlite
+        db_path: ${env.SQLITE_STORE_DIR:~/.llama/distributions/remote-vllm}/responses_store.db
+  eval:
+  - provider_id: meta-reference
+    provider_type: inline::meta-reference
+    config:
+      kvstore:
+        type: sqlite
+        namespace: null
+        db_path: ${env.SQLITE_STORE_DIR:~/.llama/distributions/remote-vllm}/meta_reference_eval.db
+  datasetio:
+  - provider_id: huggingface
+    provider_type: remote::huggingface
+    config:
+      kvstore:
+        type: sqlite
+        namespace: null
+        db_path: ${env.SQLITE_STORE_DIR:~/.llama/distributions/remote-vllm}/huggingface_datasetio.db
+  - provider_id: localfs
+    provider_type: inline::localfs
+    config:
+      kvstore:
+        type: sqlite
+        namespace: null
+        db_path: ${env.SQLITE_STORE_DIR:~/.llama/distributions/remote-vllm}/localfs_datasetio.db
+  scoring:
+  - provider_id: basic
+    provider_type: inline::basic
+    config: {}
+  - provider_id: llm-as-judge
+    provider_type: inline::llm-as-judge
+    config: {}
+  - provider_id: braintrust
+    provider_type: inline::braintrust
+    config:
+      openai_api_key: ${env.OPENAI_API_KEY:}
+  telemetry:
+  - provider_id: meta-reference
+    provider_type: inline::meta-reference
+    config:
+      service_name: "${env.OTEL_SERVICE_NAME:\u200B}"
+      sinks: ${env.TELEMETRY_SINKS:console,sqlite}
+      sqlite_db_path: ${env.SQLITE_STORE_DIR:~/.llama/distributions/remote-vllm}/trace_store.db
+  tool_runtime:
+  - provider_id: brave-search
+    provider_type: remote::brave-search
+    config:
+      api_key: ${env.BRAVE_SEARCH_API_KEY:}
+      max_results: 3
+  - provider_id: tavily-search
+    provider_type: remote::tavily-search
+    config:
+      api_key: ${env.TAVILY_SEARCH_API_KEY:}
+      max_results: 3
+  - provider_id: rag-runtime
+    provider_type: inline::rag-runtime
+    config: {}
+  - provider_id: model-context-protocol
+    provider_type: remote::model-context-protocol
+    config: {}
+  - provider_id: wolfram-alpha
+    provider_type: remote::wolfram-alpha
+    config:
+      api_key: ${env.WOLFRAM_ALPHA_API_KEY:}
+metadata_store:
+  type: sqlite
+  db_path: ${env.SQLITE_STORE_DIR:~/.llama/distributions/remote-vllm}/registry.db
+inference_store:
+  type: sqlite
+  db_path: ${env.SQLITE_STORE_DIR:~/.llama/distributions/remote-vllm}/inference_store.db
+models:
+- metadata: {}
+  model_id: ${env.INFERENCE_MODEL}
+  provider_id: vllm-inference
+  model_type: llm
+- metadata:
+    embedding_dimension: 384
+  model_id: all-MiniLM-L6-v2
+  provider_id: sentence-transformers
+  model_type: embedding
+shields: []
+vector_dbs: []
+datasets: []
+scoring_fns: []
+benchmarks: []
+tool_groups:
+- toolgroup_id: builtin::websearch
+  provider_id: tavily-search
+- toolgroup_id: builtin::rag
+  provider_id: rag-runtime
+- toolgroup_id: builtin::wolfram_alpha
+  provider_id: wolfram-alpha
+server:
+  port: 8321

--- a/llama-stack/service.yaml
+++ b/llama-stack/service.yaml
@@ -1,0 +1,14 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: llamastack-server
+  annotations:
+    argocd.argoproj.io/sync-wave: "5"
+spec:
+  ports:
+    - protocol: TCP
+      port: 8321
+      targetPort: 8321
+  type: ClusterIP
+  selector:
+    app: llamastack


### PR DESCRIPTION
Adds an instance of Llama Stack (from https://github.com/opendatahub-io/llama-stack-demos/) to our GitOps repository. I've omitted the route from the resources deployed, as we will use 3scale to manage access to the instance