### PR TITLE
Add content security policies to allow images to load in lightspeed

### DIFF
--- a/developer-hub/app-config.yaml
+++ b/developer-hub/app-config.yaml
@@ -42,6 +42,13 @@ data:
       baseUrl: "${RHDH_BASE_URL}"
       cors:
         origin: "${RHDH_BASE_URL}"
+      csp:
+        upgrade-insecure-requests: false
+        img-src:
+          - "'self'"
+          - "data:"
+          - https://img.freepik.com
+          - https://cdn.dribbble.com
     signInPage: oidc
     catalog:
       providers:


### PR DESCRIPTION

This PR adds the content security policy to allow images in the lightspeed plugin such as profile placeholder picture and footer image.


![image](https://github.com/user-attachments/assets/6b630ce0-0a13-425c-a579-b298b0f2ce6c)