### PR TITLE
[RHDHPAI-919] Add postgres resources for feedback storage

### DIFF
--- a/feedback-postgres/base/deployment.yaml
+++ b/feedback-postgres/base/deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+      - name: postgres
+        image: postgres:15
+        ports:
+        - containerPort: 5432
+        env:
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: postgres-info
+              key: password
+        - name: POSTGRES_USER
+          valueFrom:
+            secretKeyRef:
+              name: postgres-info
+              key: user
+        - name: POSTGRES_DB
+          valueFrom:
+            secretKeyRef:
+              name: postgres-info
+              key: db-name
+        - name: PGDATA
+          value: /var/lib/postgresql/data/pg
+        volumeMounts:
+        - name: postgres-storage
+          mountPath: /var/lib/postgresql/data
+      volumes:
+      - name: postgres-storage
+        persistentVolumeClaim:
+          claimName: feedback-postgres-pvc

--- a/feedback-postgres/base/pvc.yaml
+++ b/feedback-postgres/base/pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: feedback-postgres-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/feedback-postgres/base/service.yaml
+++ b/feedback-postgres/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: feedback-postgres-svc
+spec:
+  ports:
+  - port: 5432
+    targetPort: 5432
+  selector:
+    app: postgres
+  type: ClusterIP

--- a/feedback-postgres/kustomization.yaml
+++ b/feedback-postgres/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+  - base/deployment.yaml
+  - base/pvc.yaml
+  - base/service.yaml
+  - post-deploy-config/job.yaml
+
+namespace: feedback-postgres

--- a/feedback-postgres/post-deploy-config/job.yaml
+++ b/feedback-postgres/post-deploy-config/job.yaml
@@ -1,0 +1,51 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: configure-postgres-db
+spec:
+  template:
+    spec:
+      containers:
+      - name: postgres-job
+        image: postgres:15
+        env:
+        - name: PGPASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: postgres-info
+              key: password
+        - name: PGUSER
+          valueFrom:
+            secretKeyRef:
+              name: postgres-info
+              key: user
+        - name: PGDATABASE
+          valueFrom:
+            secretKeyRef:
+              name: postgres-info
+              key: db-name
+        - name: PGHOST
+          value: feedback-postgres-svc
+        command:
+        - sh
+        - -c
+        - |
+          echo "Waiting for Postgres to be ready..."
+          until pg_isready -h "$POSTGRES_HOST" -U "$POSTGRES_USER"; do
+            sleep 2
+          done
+          echo "Postgres is ready, creating table..."
+
+          psql <<EOF
+          CREATE TABLE IF NOT EXISTS feedback (
+            id SERIAL PRIMARY KEY,
+            user_id TEXT NOT NULL,
+            timestamp TEXT NOT NULL,
+            conversation_id TEXT NOT NULL,
+            user_question TEXT NOT NULL,
+            llm_response TEXT NOT NULL,
+            sentiment INTEGER,
+            user_feedback TEXT
+          );
+          EOF
+      restartPolicy: OnFailure


### PR DESCRIPTION
- Adds the postgres resources for use with the feedback harvester

Issue: Part of https://issues.redhat.com/browse/RHDHPAI-919

**Note:** I will open a separate PR for adding the feedback harvester sidecar to the developer-hub deployment after this postgres db is merged and setup.

The secret is already present in the namespace on the cluster.