### PR TITLE
[RHDHPAI-919] Add feedback harvester as sidecar

### DIFF
--- a/developer-hub/backstage.yaml
+++ b/developer-hub/backstage.yaml
@@ -50,7 +50,40 @@ spec:
                   - mountPath: /app-root/config/app-config-rhdh.yaml
                     name: app-config-rhdh
                     subPath: app-config-rhdh.yaml
+                  - mountPath: /app-root/tmp/data/feedback
+                    name: shared-data
+              - env:
+                  - name: PGUSER
+                    valueFrom:
+                      secretKeyRef:
+                        name: feedback-postgres-info
+                        key: user
+                  - name: PGPASSWORD
+                    valueFrom:
+                      secretKeyRef:
+                        name: feedback-postgres-info
+                        key: password
+                  - name: PGDATABASE
+                    valueFrom:
+                      secretKeyRef:
+                        name: feedback-postgres-info
+                        key: db-name
+                  - name: PGHOST
+                    value: feedback-postgres-svc.feedback-postgres.svc.cluster.local
+                  - name: PGPORT
+                    value: 5432
+                  - name: FEEDBACK_DIRECTORY
+                    value: /app-root/tmp/data/feedback
+                  - name: FETCH_FREQUENCY
+                    value: 60
+                image: 'quay.io/redhat-ai-dev/feedback-harvester:v0.1.0'
+                name: feedback-harvester
+                volumeMounts:
+                  - mountPath: /app-root/tmp/data/feedback
+                    name: shared-data
             volumes:
               - configMap:
                   name: rcsconfig
                 name: rcsconfig
+              - name: shared-data
+                emptyDir: {}

--- a/developer-hub/rcsconfig.yaml
+++ b/developer-hub/rcsconfig.yaml
@@ -25,8 +25,14 @@ data:
       default_provider: dummy
       default_model: dummymodel
       query_validation_method: disabled
+      user_data_collection:
+        feedback_disabled: false
+        feedback_storage: "/app-root/tmp/data/feedback"
     dev_config:
       enable_dev_ui: false
       disable_auth: false
       disable_tls: true
       enable_system_prompt_override: true
+    user_data_collector_config:
+      ingress_url: "https://example.ingress.com/upload"
+      user_agent: "example-agent"


### PR DESCRIPTION
- Add the feedback harvester as a sidecar that runs in the rhdh pod.
- Sets up the feedback handling in the rcsconfig and adds the emptyDir to the rhdh pod.

Issue: Part of https://issues.redhat.com/browse/RHDHPAI-919

**Note:** This depends on the postgres db being setup, so https://github.com/redhat-ai-dev/rosa-gitops/pull/18 should be completed and finalized _first_