### PR TITLE
Update redhat-ai-dev-edit.yaml

### DIFF
--- a/authorization/redhat-ai-dev-edit.yaml
+++ b/authorization/redhat-ai-dev-edit.yaml
@@ -5,7 +5,7 @@ metadata:
 subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
-    name: redhat-ai-dev-users
+    name: redhat-ai-dev-edit-users
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
Fix RoleBinding subject, seems to have missed the previous rename of the Groups