### PR TITLE
Update Ollama and App Config

### DIFF
--- a/developer-hub/app-config.yaml
+++ b/developer-hub/app-config.yaml
@@ -11,6 +11,9 @@ data:
     app:
       title: AI Dev Developer Hub
       baseUrl: "${RHDH_BASE_URL}"
+      analytics:
+        adoptionInsights:
+          licensedUsers: 50
     auth:
       environment: production
       session:

--- a/ollama/ollama-deployment.yaml
+++ b/ollama/ollama-deployment.yaml
@@ -36,7 +36,7 @@ spec:
           name: container
           env:
             - name: OLLAMA_KEEP_ALIVE
-              value: 12h
+              value: '-1m'
             - name: OLLAMA_ORIGINS
               value: '*'
           ports:


### PR DESCRIPTION
Couple unrelated changes:

- [RHDHPAI-951](https://issues.redhat.com/browse/RHDHPAI-951): Setting the `OLLAMA_KEEP_ALIVE` interval to `-1m` to prevent ollama from unloading models from memory
- Sets the licensed users field for adoption insights to 50