### PR TITLE
Create GitOps configuration for rosa-namespace-provisioner

### DIFF
--- a/rosa-namespace-provisioner/deployment-patch.yaml
+++ b/rosa-namespace-provisioner/deployment-patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rosa-namespace-provisioner
+spec:
+  template:
+    spec:
+      containers:
+      - name: controller
+        env:
+        - name: TARGET_GROUP_NAME
+          value: "redhat-ai-dev-edit-users" 

--- a/rosa-namespace-provisioner/kustomization.yaml
+++ b/rosa-namespace-provisioner/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - https://github.com/redhat-ai-dev/rosa-namespace-provisioner/blob/main/deploy/kustomization.yaml
+
+patchesStrategicMerge:
+  - deployment-patch.yaml 


### PR DESCRIPTION
- Adds a GitOps configuration for the [rosa-namespace-provisioner](https://github.com/redhat-ai-dev/rosa-namespace-provisioner/)
- Adds a deployment patch that sets the watched group name to `redhat-ai-dev-edit-users`