### PR TITLE
Make ollama models configurable via CM

### DIFF
--- a/ollama/README.md
+++ b/ollama/README.md
@@ -1,0 +1,3 @@
+# Ollama
+
+If you want to update the models that are served with ollama, update the Config Map `ollama-models-config`.

--- a/ollama/README.md
+++ b/ollama/README.md
@@ -1,3 +1,8 @@
 # Ollama
 
 If you want to update the models that are served with ollama, update the Config Map `ollama-models-config`.
+
+## Currently Deployed Default Models
+
+- llama3.1:8b
+- granite3.3:8b

--- a/ollama/kustomization.yaml
+++ b/ollama/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ollama-models-config.yaml
   - ollama-deployment.yaml
   - ollama-service.yaml
   - ollama-pvc.yaml

--- a/ollama/ollama-deployment.yaml
+++ b/ollama/ollama-deployment.yaml
@@ -17,6 +17,9 @@ spec:
         - name: ollama-storage
           persistentVolumeClaim:
             claimName: ollama-storage
+        - name: model-config
+          configMap:
+            name: ollama-models-config
       containers:
         - resources:
             limits:
@@ -31,8 +34,12 @@ spec:
               exec:
                 command:
                   - /bin/sh
-                  - '-c'
-                  - 'ollama pull granite3-dense:8b; ollama list'
+                  - -c
+                  - |
+                    while read model; do
+                      echo "Pulling model: $model"
+                      ollama pull $model
+                    done < /app/models/models.txt && ollama list
           name: container
           env:
             - name: OLLAMA_KEEP_ALIVE
@@ -46,6 +53,8 @@ spec:
           volumeMounts:
             - name: ollama-storage
               mountPath: /.ollama
+            - name: model-config
+              mountPath: /app/models
           terminationMessagePolicy: File
           image: 'quay.io/redhat-ai-dev/ollama-ubi:v0.9.1'
       restartPolicy: Always

--- a/ollama/ollama-models-config.yaml
+++ b/ollama/ollama-models-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ollama-models-config
+data:
+  models.txt: |
+    llama3.1:8b
+    granite3.3:8b


### PR DESCRIPTION
- Adds in a CM with the models to be used with ollama
- Updated ollama deployment to mount the CM and read the model list on postStart
- Tested it on my cluster:
<img width="742" height="518" alt="Screenshot 2025-07-18 at 6 55 20 PM" src="https://github.com/user-attachments/assets/f6a2294e-6a59-424b-af4c-61f8ff4c958a" />
<img width="552" height="570" alt="Screenshot 2025-07-18 at 6 55 42 PM" src="https://github.com/user-attachments/assets/8d3c197d-b282-44c0-b016-6bf7f21edb4b" />
