### PR TITLE
Add ollama-model-viewer to ollama ArgoCD app

### DIFF
--- a/ollama/README.md
+++ b/ollama/README.md
@@ -6,3 +6,7 @@ If you want to update the models that are served with ollama, update the Config 
 
 - llama3.1:8b
 - granite3.3:8b
+
+## Ollama Model Viewer
+
+An instance of the [Ollama Model Viewer](https://github.com/redhat-ai-dev/ollama-model-viewer) is deployed in the same namespace as Ollama, providing a basic UI to view deployed models and see GPU usage.

--- a/ollama/kustomization.yaml
+++ b/ollama/kustomization.yaml
@@ -5,5 +5,6 @@ resources:
   - ollama-deployment.yaml
   - ollama-service.yaml
   - ollama-pvc.yaml
+  - https://github.com/redhat-ai-dev/ollama-model-viewer/deploy?ref=main
 
 namespace: ollama


### PR DESCRIPTION
Adds the [ollama-model-viewer](https://github.com/redhat-ai-dev/ollama-model-viewer) to the Ollama ArgoCD Application