### PR TITLE
Use just gemma3:27b and update model context size

### DIFF
--- a/ollama/ollama-deployment.yaml
+++ b/ollama/ollama-deployment.yaml
@@ -46,6 +46,8 @@ spec:
               value: '-1m'
             - name: OLLAMA_ORIGINS
               value: '*'
+            - name: OLLAMA_CONTEXT_LENGTH
+              value: '16384'
           ports:
             - containerPort: 11434
               protocol: TCP

--- a/ollama/ollama-models-config.yaml
+++ b/ollama/ollama-models-config.yaml
@@ -5,4 +5,3 @@ metadata:
 data:
   models.txt: |
     gemma3:27b
-    llama3.2:1b


### PR DESCRIPTION
- We had issues running a smaller model alongside gemma3:27b on our GPUs, so removing the smaller model
- Default context size for Ollama (2048) was too small, so bumping it up to 16K which should perform better (and still runs entirely within our GPUs)