### PR TITLE
Add user 'lyoon' to redhat-ai-dev-users

### DIFF
--- a/authorization/redhat-ai-dev-users.yaml
+++ b/authorization/redhat-ai-dev-users.yaml
@@ -17,6 +17,7 @@ users:
   - eyuen
   - tkral
   - ktsao
+  - lyoon
   - alizardo
   - tguittet
   - jperezdealgaba


### PR DESCRIPTION
Adding @JslYoon as user, so he can have access on our cluster and be able to check logs on RHDH AI Development env etc etc.